### PR TITLE
fix: use println! with "{}"

### DIFF
--- a/part2.html
+++ b/part2.html
@@ -236,7 +236,7 @@ fn greet(name: &str) -> String {
 }
 
 fn main() {
-    println!(greet("Rust"));
+    println!("{}", greet("Rust"));
 }
 ```
 


### PR DESCRIPTION
Thanks for the workshop :) 

I tried the example and the compiler complained that it expected a literal. If I extend it like this `println!("{}", greet("Rust"));`, it works.